### PR TITLE
Add dynamic copyright year to footer

### DIFF
--- a/about.html
+++ b/about.html
@@ -199,7 +199,8 @@
           <a href="about.html">About</a>
           <a href="https://github.com/BenjiCoder24" target="_blank" rel="noopener">GitHub</a>
         </div>
-        <p>Copyright 2024 CodeWithBenji.AI. All rights reserved.</p>
+        <p>Copyright <span id="year"></span> CodeWithBenji.AI. All rights reserved.</p>
+        <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
       </div>
     </footer>
     <script src="script.js"></script>

--- a/index.html
+++ b/index.html
@@ -182,7 +182,8 @@
           <a href="about.html">About</a>
           <a href="https://github.com/BenjiCoder24" target="_blank" rel="noopener">GitHub</a>
         </div>
-        <p>Copyright 2024 CodeWithBenji.AI. All rights reserved.</p>
+        <p>Copyright <span id="year"></span> CodeWithBenji.AI. All rights reserved.</p>
+        <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
       </div>
     </footer>
     <script src="script.js"></script>

--- a/pictures.html
+++ b/pictures.html
@@ -374,7 +374,8 @@
           <a href="about.html">About</a>
           <a href="https://github.com/BenjiCoder24" target="_blank" rel="noopener">GitHub</a>
         </div>
-        <p>Copyright 2024 CodeWithBenji.AI. All rights reserved.</p>
+        <p>Copyright <span id="year"></span> CodeWithBenji.AI. All rights reserved.</p>
+        <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
       </div>
     </footer>
     <script src="script.js"></script>

--- a/resources.html
+++ b/resources.html
@@ -376,7 +376,8 @@
           <a href="about.html">About</a>
           <a href="https://github.com/BenjiCoder24" target="_blank" rel="noopener">GitHub</a>
         </div>
-        <p>Copyright 2024 CodeWithBenji.AI. All rights reserved.</p>
+        <p>Copyright <span id="year"></span> CodeWithBenji.AI. All rights reserved.</p>
+        <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
       </div>
     </footer>
     <script src="script.js"></script>

--- a/schedule.html
+++ b/schedule.html
@@ -732,7 +732,8 @@
           <a href="about.html">About</a>
           <a href="https://github.com/BenjiCoder24" target="_blank" rel="noopener">GitHub</a>
         </div>
-        <p>Copyright 2024 CodeWithBenji.AI. All rights reserved.</p>
+        <p>Copyright <span id="year"></span> CodeWithBenji.AI. All rights reserved.</p>
+        <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
       </div>
     </footer>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,11 @@
 // CodeWithBenji.AI - Modern JavaScript Interactions
 
 document.addEventListener('DOMContentLoaded', function() {
+  // Set dynamic copyright year
+  const yearElements = document.querySelectorAll('#year, .footer-year');
+  const currentYear = new Date().getFullYear();
+  yearElements.forEach(el => el.textContent = currentYear);
+
   // Smooth page fade-in
   document.body.style.opacity = 0;
   document.body.style.transition = 'opacity 0.5s ease-out';

--- a/sessions.html
+++ b/sessions.html
@@ -549,7 +549,8 @@
           <a href="about.html">About</a>
           <a href="https://github.com/BenjiCoder24" target="_blank" rel="noopener">GitHub</a>
         </div>
-        <p>Copyright 2024 CodeWithBenji.AI. All rights reserved.</p>
+        <p>Copyright <span id="year"></span> CodeWithBenji.AI. All rights reserved.</p>
+        <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
       </div>
     </footer>
     <script src="script.js"></script>

--- a/sessions_details/chatbot.html
+++ b/sessions_details/chatbot.html
@@ -234,7 +234,7 @@
       </article>
     </main>
     <footer>
-      <p>Copyright © 2024. All rights reserved.</p>
+      <p>Copyright © <span class="footer-year"></span>. All rights reserved.</p>
     </footer>
     <script src="../script.js"></script>
   </body>

--- a/sessions_details/climate_analysis.html
+++ b/sessions_details/climate_analysis.html
@@ -204,7 +204,7 @@ def get_temperature_data():
       </section>
     </main>
     <footer>
-      <p>Copyright © 2024. All rights reserved.</p>
+      <p>Copyright © <span class="footer-year"></span>. All rights reserved.</p>
     </footer>
     <script src="../script.js"></script>
   </body>

--- a/sessions_details/cursor_ide.html
+++ b/sessions_details/cursor_ide.html
@@ -332,7 +332,7 @@ new Dashboard({
     </main>
     
     <footer>
-      <p>Copyright © 2024. All rights reserved.</p>
+      <p>Copyright © <span class="footer-year"></span>. All rights reserved.</p>
     </footer>
     <script src="../script.js"></script>
   </body>

--- a/sessions_details/functions_and_exceptions.html
+++ b/sessions_details/functions_and_exceptions.html
@@ -165,7 +165,7 @@ print(f"You entered: {number}")</code></pre>
       </article>
     </main>
     <footer>
-      <p>Copyright © 2024. All rights reserved.</p>
+      <p>Copyright © <span class="footer-year"></span>. All rights reserved.</p>
     </footer>
     <script src="../script.js"></script>
   </body>

--- a/sessions_details/gpt_features.html
+++ b/sessions_details/gpt_features.html
@@ -693,7 +693,7 @@ summarizeJiraIssue('PROJECT-123')
       </article>
     </main>
     <footer>
-        <p>Copyright &copy; 2024 Programming Tutorials: From Foundations to AI</p>
+        <p>Copyright © <span class="footer-year"></span> Programming Tutorials: From Foundations to AI</p>
         <p>Licensed under the MIT License - see the LICENSE file for details.</p>
     </footer>
     <script src="../script.js"></script>

--- a/sessions_details/htmlintro.html
+++ b/sessions_details/htmlintro.html
@@ -133,7 +133,7 @@
       </code></pre>
     </main>
     <footer>
-      <p>Copyright © 2024. All rights reserved.</p>
+      <p>Copyright © <span class="footer-year"></span>. All rights reserved.</p>
     </footer>
     <script src="../script.js"></script>
   </body>

--- a/sessions_details/introjs.html
+++ b/sessions_details/introjs.html
@@ -293,7 +293,7 @@ function draw() {
         </article>
     </main>
     <footer>
-        <p>Copyright © 2024. All rights reserved.</p>
+        <p>Copyright © <span class="footer-year"></span>. All rights reserved.</p>
     </footer>
     <script src="../script.js"></script>
 </body>

--- a/sessions_details/js_ball_bounce.html
+++ b/sessions_details/js_ball_bounce.html
@@ -221,7 +221,7 @@ function keyPressed() {
         </article>
     </main>
     <footer>
-        <p>Copyright © 2024. All rights reserved.</p>
+        <p>Copyright © <span class="footer-year"></span>. All rights reserved.</p>
     </footer>
     <script src="../script.js"></script>
 </body>

--- a/sessions_details/js_html_chat_bot.html
+++ b/sessions_details/js_html_chat_bot.html
@@ -214,7 +214,7 @@ function logMessage(message) {
         </div>
     </main>
     <footer>
-        <p>Copyright © 2024. All rights reserved.</p>
+        <p>Copyright © <span class="footer-year"></span>. All rights reserved.</p>
     </footer>
     <script src="../script.js"></script>
 </body>

--- a/sessions_details/js_html_intro.html
+++ b/sessions_details/js_html_intro.html
@@ -161,7 +161,7 @@ function sendMessage() {
         </article>
     </main>
     <footer>
-        <p>Copyright © 2024. All rights reserved.</p>
+        <p>Copyright © <span class="footer-year"></span>. All rights reserved.</p>
     </footer>
     <script src="../script.js"></script>
 </body>

--- a/sessions_details/js_in_html.html
+++ b/sessions_details/js_in_html.html
@@ -161,7 +161,7 @@ function sendMessage() {
         </article>
     </main>
     <footer>
-        <p>Copyright © 2024. All rights reserved.</p>
+        <p>Copyright © <span class="footer-year"></span>. All rights reserved.</p>
     </footer>
     <script src="../script.js"></script>
 </body>

--- a/sessions_details/oop_moving_objects.html
+++ b/sessions_details/oop_moving_objects.html
@@ -261,7 +261,7 @@ canvas {
       </article>
     </main>
     <footer>
-      <p>Copyright © 2024. All rights reserved.</p>
+      <p>Copyright © <span class="footer-year"></span>. All rights reserved.</p>
     </footer>
     <script src="../script.js"></script>
   </body>

--- a/sessions_details/openai_chat.html
+++ b/sessions_details/openai_chat.html
@@ -406,7 +406,7 @@ vercel</code></pre>
     </div>
     
     <footer>
-      <p>Copyright © 2024. All rights reserved.</p>
+      <p>Copyright © <span class="footer-year"></span>. All rights reserved.</p>
     </footer>
     <script src="../script.js"></script>
 </body>

--- a/sessions_details/python_control_structures.html
+++ b/sessions_details/python_control_structures.html
@@ -70,7 +70,7 @@ else:
         </article>
     </main>
     <footer>
-        <p>Copyright © 2024. All rights reserved.</p>
+        <p>Copyright © <span class="footer-year"></span>. All rights reserved.</p>
     </footer>
     <script src="../script.js"></script>
 </body>

--- a/sessions_details/python_intro.html
+++ b/sessions_details/python_intro.html
@@ -71,7 +71,7 @@ for name, color in names_and_colors:
         </article>
     </main>
     <footer>
-        <p>Copyright © 2024. All rights reserved.</p>
+        <p>Copyright © <span class="footer-year"></span>. All rights reserved.</p>
     </footer>
     <script src="../script.js"></script>
 </body>

--- a/sessions_details/pythonoop.html
+++ b/sessions_details/pythonoop.html
@@ -134,7 +134,7 @@ item4.display()
         </article>
     </main>
     <footer>
-        <p>Copyright © 2024. All rights reserved.</p>
+        <p>Copyright © <span class="footer-year"></span>. All rights reserved.</p>
     </footer>
     <script src="../script.js"></script>
 </body>

--- a/sessions_details/recipi_detail.html
+++ b/sessions_details/recipi_detail.html
@@ -152,7 +152,7 @@
   </main>
 
   <footer>
-    <p>Copyright © 2024. All rights reserved.</p>
+    <p>Copyright © <span class="footer-year"></span>. All rights reserved.</p>
   </footer>
   <script src="../script.js"></script>
 </body>

--- a/sessions_details/sign_languange.html
+++ b/sessions_details/sign_languange.html
@@ -105,7 +105,7 @@
   </main>
 
   <footer>
-    <p>Copyright © 2024. All rights reserved.</p>
+    <p>Copyright © <span class="footer-year"></span>. All rights reserved.</p>
   </footer>
   <script src="../script.js"></script>
 </body>


### PR DESCRIPTION
- Replace hardcoded 2024 with JavaScript-generated current year
- Update all main pages with inline script fallback
- Update session detail pages with footer-year class
- Ensure copyright always displays current year automatically